### PR TITLE
Update minecraft versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-val baseVersion = "0.0.1"
+val baseVersion = "0.0.2"
 val commitHash = System.getenv("COMMIT_HASH")
 val snapshotVersion = "${baseVersion}-dev.$commitHash"
 

--- a/npc-paper/build.gradle.kts
+++ b/npc-paper/build.gradle.kts
@@ -42,7 +42,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("paper")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported versions in the `npc-paper/build.gradle.kts` file for the `modrinth` configuration.

* Added support for Minecraft versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` to the `modrinth` configuration. (`npc-paper/build.gradle.kts`, [npc-paper/build.gradle.ktsL45-R49](diffhunk://#diff-11dbc8d329e52a67fb4d257d96f98ef31d1cb24e689d98d3a3f6654206f7fea0L45-R49))